### PR TITLE
Remover o nome da HE:labs e Improve It

### DIFF
--- a/_includes/contribute.html
+++ b/_includes/contribute.html
@@ -1,7 +1,7 @@
 <article id="contribute" class="center">
   <h1>Como contribuir</h1>
 
-  <p>O DesenvolvimentoÁgil.com.br é um projeto Open Source feito com o apoio da Improve It com a HE:labs. Mudanças e adições tanto no conteúdo quando no layout são bem-vindas, desde que sigam o Guideline de contribuição para o projeto.</p>
+  <p>O DesenvolvimentoÁgil.com.br é um projeto Open Source feito pela comunidade de desenvolvimento ágil do Brasil. Mudanças e adições tanto no conteúdo quando no layout são bem-vindas, desde que sigam o Guideline de contribuição para o projeto.</p>
 
   <h2>Começando</h2>
 

--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 layout: default
 title: Aprenda sobre Desenvolvimento Ágil de Software
 keywords: extreme programming programing xp programação extrema metodologia valores scrum scrum ágil agile gestão gerência gerenciamento planejamento projeto
-description: Este é um guia Open Source sobre Desenvolvimento Ágil feito com o apoio da Improve It e da HE:labs
+description: Este é um guia Open Source sobre Desenvolvimento Ágil feito pela comunidade de desenvolvimento ágil do Brasil
 ---
 
 <hgroup>
   <h1>Aprenda sobre <br /> Desenvolvimento Ágil de Software</h1>
-  <h2>Este é um guia Open Source sobre Desenvolvimento Ágil feito com o apoio da <a target="_blank" href="http://improveit.com.br" title="Improve It">Improve It</a> e da <a target="_blank" href="http://helabs.com.br" title="HE:labs">HE:labs</a></h2>
+  <h2>Este é um guia Open Source sobre Desenvolvimento Ágil feito pela comunidade de desenvolvimento ágil do Brasil</h2>
 </hgroup>
 
 <img src="/images/agile-icon-medium.png" width="62" height="71" alt="Desenvolvimento Ágil" id="agile-icon"/>


### PR DESCRIPTION
O projeto é pra ser mantido pela comunidade. A HE:labs e Improve IT só deram o pontapé inicial.
