### PR TITLE
Tira o acento do DesenvolvimentoÁgil.com.br

### DIFF
--- a/_includes/contribute.html
+++ b/_includes/contribute.html
@@ -1,7 +1,7 @@
 <article id="contribute" class="center">
   <h1>Como contribuir</h1>
 
-  <p>O DesenvolvimentoÁgil.com.br é um projeto Open Source feito pela comunidade de desenvolvimento ágil do Brasil. Mudanças e adições tanto no conteúdo quando no layout são bem-vindas, desde que sigam o Guideline de contribuição para o projeto.</p>
+  <p>O DesenvolvimentoAgil.com.br é um projeto Open Source feito pela comunidade de desenvolvimento ágil do Brasil. Mudanças e adições tanto no conteúdo quando no layout são bem-vindas, desde que sigam o Guideline de contribuição para o projeto.</p>
 
   <h2>Começando</h2>
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <footer>
   <div class="center">
-    <span> DesenvolvimentoÁgil.com.br - 2013 </span>
+    <span> DesenvolvimentoAgil.com.br - 2013 </span>
 
     <div id="footer-links">
       <a target="_blank" href="http://improveit.com.br" title="Improve It" class="improveit-link"><img src="/images/logo-improveit.png" /></a>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,5 +1,5 @@
 <head>
-  <title>{{ page.title }}{% if page.layout == "scrum" %} | Scrum{% elsif page.layout == "xp" %} | XP{% endif %} | DesenvolvimentoÁgil.com.br</title>
+  <title>{{ page.title }}{% if page.layout == "scrum" %} | Scrum{% elsif page.layout == "xp" %} | XP{% endif %} | DesenvolvimentoAgil.com.br</title>
   <meta charset='utf-8' />
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
   <meta name="keywords" content="{{ page.keywords }}" />

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,7 +7,7 @@
       <header id="header">
         <div id="masthead">
           <div class="center">
-            <h1><a href="/" id="logo" title="DesenvolvimentoÁgil.com.br">DesenvolvimentoÁgil.com.br</a></h1>
+            <h1><a href="/" id="logo" title="DesenvolvimentoAgil.com.br">DesenvolvimentoAgil.com.br</a></h1>
             <nav id="main-navigation">
               <ul>
                 <li><a href="/xp" title="XP">XP</a></li>

--- a/_layouts/scrum.html
+++ b/_layouts/scrum.html
@@ -7,7 +7,7 @@
       <header id="header">
         <div id="masthead">
           <div class="center">
-            <h1><a href="/" id="logo" title="DesenvolvimentoÁgil.com.br">DesenvolvimentoÁgil.com.br</a></h1>
+            <h1><a href="/" id="logo" title="DesenvolvimentoAgil.com.br">DesenvolvimentoAgil.com.br</a></h1>
             <nav id="main-navigation">
               <ul>
                 <li><a href="/xp" title="XP">XP</a></li>

--- a/_layouts/xp.html
+++ b/_layouts/xp.html
@@ -7,7 +7,7 @@
       <header id="header">
         <div id="masthead">
           <div class="center">
-            <h1><a href="/" id="logo" title="DesenvolvimentoÁgil.com.br">DesenvolvimentoÁgil.com.br</a></h1>
+            <h1><a href="/" id="logo" title="DesenvolvimentoAgil.com.br">DesenvolvimentoAgil.com.br</a></h1>
             <nav id="main-navigation">
               <ul>
                 <li class="current"><a href="/xp" title="XP">XP</a></li>

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ description: Este é um guia Open Source sobre Desenvolvimento Ágil feito pela 
 
 <hgroup>
   <h1>Aprenda sobre <br /> Desenvolvimento Ágil de Software</h1>
-  <h2>Este é um guia Open Source sobre Desenvolvimento Ágil feito pela comunidade de desenvolvimento ágil do Brasil</h2>
+  <h2>Este é um guia Open Source sobre Desenvolvimento Ágil feito pela comunidade de Desenvolvimento Ágil do Brasil</h2>
 </hgroup>
 
 <img src="/images/agile-icon-medium.png" width="62" height="71" alt="Desenvolvimento Ágil" id="agile-icon"/>


### PR DESCRIPTION
Acredito que seja melhor usarmos DesenvolvimentoAgil.com.br sem acento,
porque algumas pessoas tentaram acessar com acento e o domínio não
existe.

Se utilizarmos sem o acento, não haverá a possibilidade desse tipo de
confusão. O que vocês acham?
